### PR TITLE
Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "clone-deep": "^0.2.4",
     "expand-pkg": "^0.1.5",
     "fs-exists-sync": "^0.1.0",
-    "generate": "^0.12.0",
     "lazy-cache": "^2.0.1",
     "mixin-deep": "^1.1.3",
     "namify": "^0.1.3",
@@ -36,6 +35,7 @@
   "devDependencies": {
     "delete": "^0.3.2",
     "engine-base": "^0.1.2",
+    "generate": "^0.12.1",
     "gitty": "^3.3.6",
     "gulp-format-md": "^0.1.10",
     "is-valid-app": "^0.2.1",

--- a/test/test.js
+++ b/test/test.js
@@ -131,9 +131,9 @@ describe('generate-data', function() {
           return;
         }
 
-        assert.equal(ctx.repository, 'jonschlinkert/test-project');
+        assert.equal(ctx.repository, 'doowb/test-project');
         assert.equal(ctx.username, 'jonschlinkert');
-        assert.equal(ctx.owner, 'jonschlinkert');
+        assert.equal(ctx.owner, 'doowb');
         cb();
       });
     });
@@ -310,9 +310,9 @@ describe('generate-data', function() {
           return;
         }
 
-        assert.equal(ctx.repository, 'jonschlinkert/test-project');
+        assert.equal(ctx.repository, 'doowb/test-project');
         assert.equal(ctx.username, 'jonschlinkert');
-        assert.equal(ctx.owner, 'jonschlinkert');
+        assert.equal(ctx.owner, 'doowb');
         cb();
       });
     });


### PR DESCRIPTION
@jonschlinkert just a few fixes I noticed. Doing the PR in case you already saw these.
- move `generate` to `devDependencies`
- use `doowb/test-project` in a couple of the tests since the `repository.url` in `test/fixtures/project/package.json` is `https://github.com/doowb/test-project`.
- use `doowb` in a couple of the tests for the `owner` because of the `repository.url`.
